### PR TITLE
Add checks for Arch, Manjaro, Gentoo package managers

### DIFF
--- a/519.yml
+++ b/519.yml
@@ -36,6 +36,10 @@
          cmd: dnf --version
          range: ^4.9.0
      - version:
+         comment: Package manager for Gentoo Linux
+         cmd: emerge --version
+         range: ^3.0.28
+     - version:
          comment: Package manager for Windows.
          cmd: choco -v
          range: ^0.11.3

--- a/519.yml
+++ b/519.yml
@@ -36,6 +36,10 @@
          cmd: dnf --version
          range: ^4.9.0
      - version:
+         comment: Package manager for Arch and Manjaro Linux
+         cmd: pacman --version
+         range: ^6.0.1
+     - version:
          comment: Package manager for Gentoo Linux
          cmd: emerge --version
          range: ^3.0.28


### PR DESCRIPTION
This PR adds checks for these package managers:

- pacman 6.0.1 (Arch and Manjaro Linux)
- portage 3.0.28 (Gentoo Linux)

As of the time of this PR these are the most up-to-date stable versions of these package managers, from official repositories. I have tested both of these checks to make sure they work.